### PR TITLE
fix: guard truncated status response payloads

### DIFF
--- a/platforms/windows/desktop-main/vibe_code_config_tool/src/comm/protocol.py
+++ b/platforms/windows/desktop-main/vibe_code_config_tool/src/comm/protocol.py
@@ -133,13 +133,19 @@ def parse_device_frame(raw: bytes):
 
 def parse_status_response(data: bytes) -> dict:
     """解析 BLE 状态响应 (PKT_STATUS_RESP)"""
-    if not data:
+    if not data or len(data) < 2:
         return {}
     offset = 0
     connected = data[offset]; offset += 1
     name_len = data[offset]; offset += 1
+    if offset + name_len > len(data):
+        return {}
     name = data[offset:offset + name_len].decode("utf-8", errors="replace"); offset += name_len
+    if offset >= len(data):
+        return {}
     mac_len = data[offset]; offset += 1
+    if offset + mac_len > len(data):
+        return {}
     mac = data[offset:offset + mac_len].decode("utf-8", errors="replace"); offset += mac_len
     is_target = data[offset] if offset < len(data) else 0
     return {

--- a/platforms/windows/desktop-main/vibe_code_config_tool/tests/test_protocol.py
+++ b/platforms/windows/desktop-main/vibe_code_config_tool/tests/test_protocol.py
@@ -1,0 +1,50 @@
+import unittest
+
+from src.comm.protocol import parse_status_response
+
+
+class ParseStatusResponseTests(unittest.TestCase):
+    def test_parse_status_response_valid_payload(self):
+        payload = bytes([1, 4]) + b"Vibe" + bytes([5]) + b"AA:BB" + bytes([1])
+
+        self.assertEqual(
+            parse_status_response(payload),
+            {
+                "connected": True,
+                "name": "Vibe",
+                "mac": "AA:BB",
+                "is_target": True,
+            },
+        )
+
+    def test_parse_status_response_empty_payload(self):
+        self.assertEqual(parse_status_response(b""), {})
+
+    def test_parse_status_response_single_byte_payload(self):
+        self.assertEqual(parse_status_response(b"\x01"), {})
+
+    def test_parse_status_response_truncated_name(self):
+        self.assertEqual(parse_status_response(bytes([1, 4]) + b"AB"), {})
+
+    def test_parse_status_response_missing_mac_length(self):
+        self.assertEqual(parse_status_response(bytes([1, 1]) + b"A"), {})
+
+    def test_parse_status_response_truncated_mac(self):
+        self.assertEqual(parse_status_response(bytes([1, 1]) + b"A" + bytes([4]) + b"BC"), {})
+
+    def test_parse_status_response_missing_is_target_defaults_false(self):
+        payload = bytes([1, 1]) + b"A" + bytes([2]) + b"BC"
+
+        self.assertEqual(
+            parse_status_response(payload),
+            {
+                "connected": True,
+                "name": "A",
+                "mac": "BC",
+                "is_target": False,
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
﻿## Summary
- harden `parse_status_response()` so truncated BLE status payloads return `{}` instead of raising or producing misleading partial data
- add focused regression tests for valid, empty, and truncated status payloads

## Why
`parse_status_response()` currently reads length-prefixed fields without validating bounds first. A short bridge payload can raise in the receive path, and some malformed payloads can silently produce partial `name` / `mac` values.

## Testing
- `python -m unittest discover -s tests -p "test_*.py"`
