### PR TITLE
fix: ignore trailing bytes in pic state response

### DIFF
--- a/platforms/windows/desktop-main/vibe_code_config_tool/src/comm/protocol.py
+++ b/platforms/windows/desktop-main/vibe_code_config_tool/src/comm/protocol.py
@@ -168,7 +168,7 @@ def parse_pic_state_response(data: bytes) -> dict:
     """
     if len(data) < 9:
         return {}
-    mode, start_index, pic_length, frame_interval, all_mode_max_pic = struct.unpack("<BHHHH", data)
+    mode, start_index, pic_length, frame_interval, all_mode_max_pic = struct.unpack("<BHHHH", data[:9])
     return {
         "mode": mode,
         "start_index": start_index,

--- a/platforms/windows/desktop-main/vibe_code_config_tool/tests/test_protocol.py
+++ b/platforms/windows/desktop-main/vibe_code_config_tool/tests/test_protocol.py
@@ -1,0 +1,23 @@
+import unittest
+
+from src.comm.protocol import parse_pic_state_response
+
+
+class ParsePicStateResponseTests(unittest.TestCase):
+    def test_parse_pic_state_response_ignores_trailing_bytes(self):
+        payload = bytes([1, 2, 0, 3, 0, 4, 0, 5, 0, 99])
+
+        self.assertEqual(
+            parse_pic_state_response(payload),
+            {
+                "mode": 1,
+                "start_index": 2,
+                "pic_length": 3,
+                "frame_interval": 4,
+                "all_mode_max_pic": 5,
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- ignore trailing bytes when parsing pic state responses
- add a regression test for the protocol parser

## Verification
- python -m unittest tests.test_protocol -v
