### PR TITLE
fix: accept current config schema version

### DIFF
--- a/platforms/windows/desktop-main/vibe_code_config_tool/src/core/config_manager.py
+++ b/platforms/windows/desktop-main/vibe_code_config_tool/src/core/config_manager.py
@@ -11,7 +11,7 @@ from .keymap import KeyboardConfig
 class ConfigManager:
     """配置文件的保存和加载"""
 
-    SCHEMA_VERSION = 1
+    SCHEMA_VERSION = 2
 
     def save(self, config: KeyboardConfig, path: str):
         """保存配置到 JSON 文件"""

--- a/platforms/windows/desktop-main/vibe_code_config_tool/tests/test_config_manager.py
+++ b/platforms/windows/desktop-main/vibe_code_config_tool/tests/test_config_manager.py
@@ -1,0 +1,25 @@
+import os
+import tempfile
+import unittest
+
+from src.core.config_manager import ConfigManager
+from src.core.keymap import KeyboardConfig
+
+
+class ConfigManagerTests(unittest.TestCase):
+    def test_save_then_load_round_trip_current_schema(self):
+        fd, path = tempfile.mkstemp(suffix=".json")
+        os.close(fd)
+        try:
+            manager = ConfigManager()
+            manager.save(KeyboardConfig(name="RoundTrip"), path)
+
+            loaded = manager.load(path)
+
+            self.assertEqual(loaded.name, "RoundTrip")
+        finally:
+            os.remove(path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- align ConfigManager with the config schema version written by KeyboardConfig
- add a round-trip test for saving and loading the current schema

## Verification
- python -m unittest tests.test_config_manager -v
